### PR TITLE
2.0.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,17 @@
 A program to generate maps from codes in the same way as Virtual Hydlide, made in an effort to help find better codes for speedrunning. 
 
-The program needs to be run in a directory with the base maps in a `basemaps` folder. The base maps are the `GR_BASE<n>.BIN` files found in the `HYDLIDE\MAP01` directory on your Virtual Hydlide CD. 
+SETUP
 
-Currently the main function is just a simple test timing the generation of 1 million maps, without doing anything else with them.
+The program needs to be run in a directory with the 5 base maps in a `basemaps` folder. The base maps are the `GR_BASE<n>.BIN` files found in the `HYDLIDE\MAP01` directory on your Virtual Hydlide CD. 
+
+If you wish to save maps, you will also need the `genmaps` directory. The program does no management of it, just spits out seeds and maps (you can view them in a hex editor if you are so inclined.)
+
+If you wish to develop, you will need to install rust.
+
+PROGRAM USAGE 
+
+The program currently does 3 things. Option 1 lets you set the difficulty of the maps generated (in case there are differences, and there are differences between Easy/Medium and Hard/PRO.)
+
+* Option 2 - Generate a single seed with your current difficulty.
+* Option 3 - Show you all 5 base maps.
+* Option 4 - Generate a large group of maps in linear seed order. You may choose the starting point (unsigned maxint 32), the amount (unsigned maxint32, but if both together >= 2^32, it's not gonna work), whether you want to 'winnow' (currently winnowing is only map 4 where the Tablet <- Sealed Caves <- Volcano path is minimized), and whether you want to save. There is no console output for this ATM, just saved maps.

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use map::_FCargs;
 
 #[macro_use(fcargs)]
 
-fn map_iteration(count: u32, start: u32, winnow: bool, save: bool ) ->  Result<bool, Box<dyn Error>> {
+fn map_iteration(count: u32, start: u32, difficulty: map::Difficulty, winnow: bool, save: bool ) ->  Result<bool, Box<dyn Error>> {
     
     let now = Instant::now();    
 
@@ -16,7 +16,7 @@ fn map_iteration(count: u32, start: u32, winnow: bool, save: bool ) ->  Result<b
         let t1 = s.spawn(|| {
             for i in start..(start + count/4) {
                 let code = &random::VHRandom::from_seed(i).get_code();
-                let m = match map::Map::from_code(&fcargs!(&code, winnow)) {
+                let m = match map::Map::from_code(&fcargs!(&code, difficulty, winnow)) {
                     Ok(m) => Some(m),
                     Err(_) => None,
                 };
@@ -29,7 +29,7 @@ fn map_iteration(count: u32, start: u32, winnow: bool, save: bool ) ->  Result<b
         let t2 = s.spawn(|| {
             for i in (start + count/4)..(start + count/2) {
                 let code = &random::VHRandom::from_seed(i).get_code();
-                let m = match map::Map::from_code(&fcargs!(&code, winnow)) {
+                let m = match map::Map::from_code(&fcargs!(&code, difficulty, winnow)) {
                     Ok(m) => Some(m),
                     Err(_) => None,
                 };
@@ -42,7 +42,7 @@ fn map_iteration(count: u32, start: u32, winnow: bool, save: bool ) ->  Result<b
         let t3 = s.spawn(|| {
             for i in (start + count/2)..(start + count/4*3) {
                 let code = &random::VHRandom::from_seed(i).get_code();
-                let m = match map::Map::from_code(&fcargs!(&code, winnow)) {
+                let m = match map::Map::from_code(&fcargs!(&code, difficulty, winnow)) {
                     Ok(m) => Some(m),
                     Err(_) => None,
                 };
@@ -58,7 +58,7 @@ fn map_iteration(count: u32, start: u32, winnow: bool, save: bool ) ->  Result<b
     });
         for i in (start + count/4*3)..(start + count) {
                 let code = &random::VHRandom::from_seed(i).get_code();
-                let m = match map::Map::from_code(&fcargs!(&code, winnow)) {
+                let m = match map::Map::from_code(&fcargs!(&code, difficulty, winnow)) {
                     Ok(m) => Some(m),
                     Err(_) => None,
                 };
@@ -80,75 +80,85 @@ fn map_iteration(count: u32, start: u32, winnow: bool, save: bool ) ->  Result<b
         return Ok(true);
 }
 
-fn main() {    
-    let mut line = String::new();
-    println!("Virtual Hydlide Map Generation Toolkit v1.1");
-    println!("1 for timing generating a million seeds");
-    println!("2 for generating and printing a specific seed");    
-    println!("3 to generate ascii for all 5 base maps");
-    println!("4 to generate a given number of seeds, possibly winnowing the results out and saving only the remainder.");
-    let _bytecount = std::io::stdin().read_line(&mut line).unwrap();        
-    let choice = line.trim_end().parse::<u8>().unwrap();
-    if choice == 2 {
-        println!("Enter a seed string (10 characters)");
-        println!("♂ is Alt-11, ♀ is Alt-12");
-        let mut line2 = String::new();
-        let _seedcount = std::io::stdin().read_line(&mut line2).unwrap();
-        while line2.len() > 10 {
-            line2.pop();
-        }        
-        if line2.len() == 10 {
-            let map = map::Map::from_code(&fcargs!(line2.as_str())).unwrap();
-            map.print_map();
-            println!("Legend");
-            println!("\x1b[93;100m{}\t{}\t{}\x1b[0m","G - Graveyard","M - Mansion", "T - Trial");
-            println!("\x1b[93;100m{}\t{}\t{}\x1b[0m","R - Ruins","V - Volcano", "F - Fairy");
-            println!("\x1b[93;100m{}\t{}\t{}\x1b[0m", "C - Castle Tablet", "@ - Start", "$ - Shop");
-            println!("\x1b[93;100m{}\t\x1b[35;100m{}\x1b[0m", "S - Sealed", "T - Transport Crystals");
+fn main() {        
+    let mut difficulty:map::Difficulty = map::Difficulty::Easy;    
+    loop {
+        let mut line = String::new();
+        println!("Virtual Hydlide Map Generation Toolkit v2.0");
+        println!("1 to set the difficulty, currently {}", map::difficulty_text(&difficulty));
+        println!("2 for generating and printing a specific seed");    
+        println!("3 to generate ascii for all 5 base maps");
+        println!("4 to generate a given number of seeds, possibly winnowing the results out and saving only the remainder.");
+        println!("Anything else to quit or crash.");
+        let _bytecount = std::io::stdin().read_line(&mut line).unwrap();
+        println!("{}",line);
+        let choice = line.trim_end().parse::<u8>().unwrap();
+        if choice == 2 {
+            println!("Enter a seed string (10 characters)");
+            println!("♂ is Alt-11, ♀ is Alt-12");
+            let mut line2 = String::new();
+            let _seedcount = std::io::stdin().read_line(&mut line2).unwrap();
+            while line2.len() > 10 {
+                line2.pop();
+            }        
+            if line2.len() == 10 {
+                let map = map::Map::from_code(&fcargs!(line2.as_str(), difficulty)).unwrap();
+                map.print_map();
+                println!("Legend");
+                println!("\x1b[93;100m{}\t{}\t{}\x1b[0m","G - Graveyard","M - Mansion", "T - Trial");
+                println!("\x1b[93;100m{}\t{}\t{}\x1b[0m","R - Ruins","V - Volcano", "F - Fairy");
+                println!("\x1b[93;100m{}\t{}\t{}\x1b[0m", "C - Castle Tablet", "@ - Start", "$ - Shop");
+                println!("\x1b[93;100m{}\t\x1b[35;100m{}\x1b[0m", "S - Sealed", "T - Transport Crystals");
+            }
+            else {
+                println!("Please enter exactly 10 characters next time. Spaces count!");
+            }
+        }
+        else if choice == 3 {
+            for i in 1..6 {
+              let m = match map::load_base_map(i) {
+                  Ok(m) => m,
+                  Err(error) => panic!("Couldn't open base map {}: {:?}",i, error),
+              };
+              m.print_map();
+              println!("--------------------------------------------------");
+            }
+        }
+        else if choice == 1 {
+            let mut difficulty_line = String::new();
+            println!("Enter the difficulty: Easy, Medium, Hard, or PRO");
+            let mut _count = std::io::stdin().read_line(&mut difficulty_line).unwrap();
+            let difficulty_string = difficulty_line.trim_end();
+            difficulty = map::text_difficulty(difficulty_string);
+        }
+        else if choice == 4 {
+            let mut save = false;
+            let mut winnow = false;
+            println!("Enter what number you want to start on");
+            let mut line_start = String::new();
+            let mut _count = std::io::stdin().read_line(&mut line_start).unwrap();        
+            let start = line_start.trim_end().parse::<u32>().unwrap();
+            println!("Enter the number of iterations you want");
+            let mut line2 = String::new();
+            _count = std::io::stdin().read_line(&mut line2).unwrap();        
+            let iterations = line2.trim_end().parse::<u32>().unwrap();
+            println!("Enter Y to winnow (winnowing criteria: perfect V->S->C walk)");
+            let mut line3 = String::new();
+            _count = std::io::stdin().read_line(&mut line3).unwrap();        
+            if line3.trim_end() == "Y" {
+                winnow = true;
+            }
+            println!("Enter Y to save (9K per file, do the math)");
+            let mut line4 = String::new();
+            _count = std::io::stdin().read_line(&mut line4).unwrap();        
+            if line4.trim_end() == "Y" {
+                save = true;
+            }
+            map_iteration(iterations, start, difficulty, winnow, save).unwrap();
         }
         else {
-            println!("Please enter exactly 10 characters next time. Spaces count!");
+            println!("You didn't pick one of the options, so we're done! Congratulations.");
+            break;
         }
-    }
-    else if choice == 3 {
-        for i in 1..6 {
-          let m = match map::load_base_map(i) {
-              Ok(m) => m,
-              Err(error) => panic!("Couldn't open base map {}: {:?}",i, error),
-          };
-          m.print_map();
-          println!("--------------------------------------------------");
-        }
-    }
-    else if choice == 1 {
-        let _ = map_iteration(1000000, 0, false, false);
-    }
-    else if choice == 4 {
-        let mut save = false;
-        let mut winnow = false;
-        println!("Enter what number you want to start on");
-        let mut line_start = String::new();
-        let mut _count = std::io::stdin().read_line(&mut line_start).unwrap();        
-        let start = line_start.trim_end().parse::<u32>().unwrap();
-        println!("Enter the number of iterations you want");
-        let mut line2 = String::new();
-        _count = std::io::stdin().read_line(&mut line2).unwrap();        
-        let iterations = line2.trim_end().parse::<u32>().unwrap();
-        println!("Enter Y to winnow (winnowing criteria: perfect V->S->C walk)");
-        let mut line3 = String::new();
-        _count = std::io::stdin().read_line(&mut line3).unwrap();        
-        if line3.trim_end() == "Y" {
-            winnow = true;
-        }
-        println!("Enter Y to save (9K per file, do the math)");
-        let mut line4 = String::new();
-        _count = std::io::stdin().read_line(&mut line4).unwrap();        
-        if line4.trim_end() == "Y" {
-            save = true;
-        }
-        map_iteration(iterations, start, winnow, save).unwrap();
-    }
-    else {
-        println!("You didn't pick one of the options, so we're done! Congratulations.")
     }
 }


### PR DESCRIPTION
Alright, we sunsetted the 'generate a million maps' option because the 'generate the number of maps you want, where you want in the number order' option exists. Instead you can select the difficulty for your later generations because we found at least one way it changes the output (starting location is changed due to the shop being replaced with a neutral tile in higher difficulties). This is both a breaking internal API forced change (difficulty is not optional) and an external UI change, and that means a new primary version number!