### PR TITLE
Adding indicators for herb patches and elevators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "vh_seed_generator"
-version = "0.1.0"
+version = "2.2.0"
 dependencies = [
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vh_seed_generator"
-version = "0.1.0"
+version = "2.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ fn main() {
                 println!("\x1b[93;100m{}\t{}\t{}\x1b[0m","R - Ruins","V - Volcano", "F - Fairy");
                 println!("\x1b[93;100m{}\t{}\t{}\x1b[0m", "C - Castle Tablet", "@ - Start", "$ - Shop");
                 println!("\x1b[93;100m{}\t\x1b[35;100m{}\x1b[0m", "S - Sealed", "T - Transport Crystals");
+                println!("\x1b[32m{}\t{}\t{}\t{}\x1b[0m", "h - herbs", "a - antidotes", "p - poison herbs","e - elevator");
             }
             else {
                 println!("Please enter exactly 10 characters next time. Spaces count!");

--- a/src/map.rs
+++ b/src/map.rs
@@ -43,7 +43,11 @@ impl Tile {
                     _ => "\x1b[33;100m▜\x1b[0m",
                 }
             }*/
-            0x9 | 0xa | 0xb | 0xc | 0x38 => "\x1b[32m█\x1b[0m",
+            0x9 => "\x1b[32m█\x1b[0m",
+            0xa => "\x1b[32mh\x1b[0m",
+            0xb => "\x1b[32ma\x1b[0m",
+            0xc => "\x1b[32mp\x1b[0m",
+            0x38 => "\x1b[32me\x1b[0m",
             0xd..=0x11 | 0x13..=0x15 | 0x34 | 0x3a => "\x1b[34m█\x1b[0m",
             0x16 | 0x31 => {
                 match self.rotation {


### PR DESCRIPTION
2.2.0: we now know what the 4 special tile pairs are: healing herbs, antidote herbs, poison herbs, and elevators to 2 special chests which will contain any non-leather shield in one, and most high tier swords except for light, including the otherwise inaccessible thunder sword. 